### PR TITLE
(Urgent) BugFix: Fixed accentColor and backgroundColor deprecation and added null safety to example. Works on Flutter 3.10 

### DIFF
--- a/example/lib/liquid_circular_progress_indicator_page.dart
+++ b/example/lib/liquid_circular_progress_indicator_page.dart
@@ -77,7 +77,7 @@ class _AnimatedLiquidCircularProgressIndicator extends StatefulWidget {
 class _AnimatedLiquidCircularProgressIndicatorState
     extends State<_AnimatedLiquidCircularProgressIndicator>
     with SingleTickerProviderStateMixin {
-  AnimationController _animationController;
+  late AnimationController _animationController;
 
   @override
   void initState() {

--- a/example/lib/liquid_custom_progress_indicator_page.dart
+++ b/example/lib/liquid_custom_progress_indicator_page.dart
@@ -69,7 +69,7 @@ class _AnimatedLiquidCustomProgressIndicator extends StatefulWidget {
 class _AnimatedLiquidCustomProgressIndicatorState
     extends State<_AnimatedLiquidCustomProgressIndicator>
     with SingleTickerProviderStateMixin {
-  AnimationController _animationController;
+  late AnimationController _animationController;
 
   @override
   void initState() {

--- a/example/lib/liquid_linear_progress_indicator_page.dart
+++ b/example/lib/liquid_linear_progress_indicator_page.dart
@@ -76,7 +76,7 @@ class _AnimatedLiquidLinearProgressIndicator extends StatefulWidget {
 class _AnimatedLiquidLinearProgressIndicatorState
     extends State<_AnimatedLiquidLinearProgressIndicator>
     with SingleTickerProviderStateMixin {
-  AnimationController _animationController;
+  late AnimationController _animationController;
 
   @override
   void initState() {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -23,7 +23,7 @@ class Example extends StatelessWidget {
               child: Text("Circular"),
               style: ButtonStyle(
                 backgroundColor:
-                    MaterialStateProperty.all<Color>(Colors.grey[300]!),
+                    MaterialStateProperty.all<Color>(Colors.grey.shade300),
               ),
               onPressed: () => Navigator.of(context).push(
                 MaterialPageRoute(
@@ -35,7 +35,7 @@ class Example extends StatelessWidget {
               child: Text("Linear"),
               style: ButtonStyle(
                 backgroundColor:
-                    MaterialStateProperty.all<Color>(Colors.grey[300]!),
+                    MaterialStateProperty.all<Color>(Colors.grey.shade300),
               ),
               onPressed: () => Navigator.of(context).push(
                 MaterialPageRoute(
@@ -47,7 +47,7 @@ class Example extends StatelessWidget {
               child: Text("Custom"),
               style: ButtonStyle(
                 backgroundColor:
-                    MaterialStateProperty.all<Color>(Colors.grey[300]!),
+                    MaterialStateProperty.all<Color>(Colors.grey.shade300),
               ),
               onPressed: () => Navigator.of(context).push(
                 MaterialPageRoute(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -19,27 +19,36 @@ class Example extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: <Widget>[
-            FlatButton(
+            TextButton(
               child: Text("Circular"),
-              color: Colors.grey[300],
+              style: ButtonStyle(
+                backgroundColor:
+                    MaterialStateProperty.all<Color>(Colors.grey[300]!),
+              ),
               onPressed: () => Navigator.of(context).push(
                 MaterialPageRoute(
                   builder: (_) => LiquidCircularProgressIndicatorPage(),
                 ),
               ),
             ),
-            FlatButton(
+            TextButton(
               child: Text("Linear"),
-              color: Colors.grey[300],
+              style: ButtonStyle(
+                backgroundColor:
+                    MaterialStateProperty.all<Color>(Colors.grey[300]!),
+              ),
               onPressed: () => Navigator.of(context).push(
                 MaterialPageRoute(
                   builder: (_) => LiquidLinearProgressIndicatorPage(),
                 ),
               ),
             ),
-            FlatButton(
+            TextButton(
               child: Text("Custom"),
-              color: Colors.grey[300],
+              style: ButtonStyle(
+                backgroundColor:
+                    MaterialStateProperty.all<Color>(Colors.grey[300]!),
+              ),
               onPressed: () => Navigator.of(context).push(
                 MaterialPageRoute(
                   builder: (_) => LiquidCustomProgressIndicatorPage(),

--- a/lib/src/liquid_circular_progress_indicator.dart
+++ b/lib/src/liquid_circular_progress_indicator.dart
@@ -42,10 +42,10 @@ class LiquidCircularProgressIndicator extends ProgressIndicator {
   }
 
   Color _getBackgroundColor(BuildContext context) =>
-      backgroundColor ?? Theme.of(context).backgroundColor;
+      backgroundColor ?? Theme.of(context).colorScheme.background;
 
   Color _getValueColor(BuildContext context) =>
-      valueColor?.value ?? Theme.of(context).accentColor;
+      valueColor?.value ?? Theme.of(context).colorScheme.secondary;
 
   @override
   State<StatefulWidget> createState() =>

--- a/lib/src/liquid_custom_progress_indicator.dart
+++ b/lib/src/liquid_custom_progress_indicator.dart
@@ -27,10 +27,10 @@ class LiquidCustomProgressIndicator extends ProgressIndicator {
         );
 
   Color _getBackgroundColor(BuildContext context) =>
-      backgroundColor ?? Theme.of(context).backgroundColor;
+      backgroundColor ?? Theme.of(context).colorScheme.background;
 
   Color _getValueColor(BuildContext context) =>
-      valueColor?.value ?? Theme.of(context).accentColor;
+      valueColor?.value ?? Theme.of(context).colorScheme.secondary;
 
   @override
   State<StatefulWidget> createState() => _LiquidCustomProgressIndicatorState();

--- a/lib/src/liquid_linear_progress_indicator.dart
+++ b/lib/src/liquid_linear_progress_indicator.dart
@@ -40,10 +40,10 @@ class LiquidLinearProgressIndicator extends ProgressIndicator {
   }
 
   Color _getBackgroundColor(BuildContext context) =>
-      backgroundColor ?? Theme.of(context).backgroundColor;
+      backgroundColor ?? Theme.of(context).colorScheme.background;
 
   Color _getValueColor(BuildContext context) =>
-      valueColor?.value ?? Theme.of(context).accentColor;
+      valueColor?.value ?? Theme.of(context).colorScheme.secondary;
 
   @override
   State<StatefulWidget> createState() => _LiquidLinearProgressIndicatorState();


### PR DESCRIPTION
**Detailed Changes:**
1. Theme.of(context).backgroundColor => Theme.of(context).colorScheme.background
2. Theme.of(context).accentColor=> Theme.of(context).colorScheme.accent
3. FlatButton => TextButton
4. Colors.grey[shade300] => Colors.grey.shade300
